### PR TITLE
chore: update action versions and add dependabot configuration

### DIFF
--- a/.github/actions/build-artifact/action.yaml
+++ b/.github/actions/build-artifact/action.yaml
@@ -31,7 +31,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: microsoft/setup-msbuild@v2
+    - uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
     - name: create output directory
       shell: pwsh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "monthly"
+      cooldown:
+        default-days: 30
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+
+  - package-ecosystem: nuget
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,6 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "all-dependencies"
+    ignore:
+      - dependency-name: "Microsoft.CodeAnalysis.Analyzers"
+      - dependency-name: "Serilog"

--- a/.github/workflows/create_pre-release-on-pr.yml
+++ b/.github/workflows/create_pre-release-on-pr.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   
     - name: build artifacts
       uses: ./.github/actions/build-artifact
@@ -31,7 +31,7 @@ jobs:
         $files
 
     - name: Upload zipped Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       id: zip-upload
       with:
         name: zip-artifact
@@ -39,7 +39,7 @@ jobs:
         path: ./dist/**.zip
         if-no-files-found: error
 
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ github.event.number }}
         PR_NOTES: |

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -14,7 +14,7 @@ jobs:
       attestations: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   
     - name: build artifacts
       uses: ./.github/actions/build-artifact
@@ -42,11 +42,11 @@ jobs:
         & "./lib/src/GenVerInfo/bin/Release/net48/GenVerInfo.exe" "./out/win/publish/KPSyncForDrive.dll" ./dist/kpsync_final.txt
 
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
         subject-path: './dist/*'
 
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const fs = require('fs').promises;


### PR DESCRIPTION
This PR improves the security of the release pipeline by pinning all action versions to SHAs, thus reducing the risk of dependency attacks. It also introduces a dependabot file which will allow us to kee our versions more up to date